### PR TITLE
Add Kotlin LSP support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -195,6 +195,23 @@
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
       }
+    },
+    {
+      "name": "kotlin-lsp",
+      "version": "0.1.0",
+      "source": "./kotlin-lsp",
+      "description": "Kotlin language server by JetBrains",
+      "category": "development",
+      "tags": [
+        "kotlin",
+        "lsp",
+        "language-server",
+        "jetbrains"
+      ],
+      "author": {
+        "name": "Piebald LLC",
+        "email": "support@piebald.ai"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code LSPs
 
-This repository contains a [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces) with plugins that offer LSP servers for TypeScript, Rust, Python, Go, Java, C/C++, PHP, Ruby, C#, PowerShell, and HTML/CSS.  [LSP servers](https://microsoft.github.io/language-server-protocol) provide powerful and familiar code intelligence features to IDEs, and now Claude Code directly.
+This repository contains a [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces) with plugins that offer LSP servers for TypeScript, Rust, Python, Go, Java, Kotlin, C/C++, PHP, Ruby, C#, PowerShell, and HTML/CSS.  [LSP servers](https://microsoft.github.io/language-server-protocol) provide powerful and familiar code intelligence features to IDEs, and now Claude Code directly.
 
 [**Claude Code is going to officially support LSP soon.**](https://www.reddit.com/r/ClaudeAI/comments/1otdfo9/lsp_is_coming_to_claude_code_and_you_can_try_it)  In 2.0.30 (October 31st) they adding the working beginnings of a system to run LSP servers from plugins automatically on startup, and an `LSP` tool (enable via `$ENABLE_LSP_TOOL=1`) that Claude can use to
 - Go to the definition for symbols (`goToDefinition`)
@@ -120,6 +120,21 @@ brew install jdtls
 ```
 
 Set `JAVA_HOME` environment variable to Java 21+ installation.
+
+</details>
+
+<details>
+<summary>Kotlin (<code>kotlin-lsp</code>)</summary>
+
+Requires **Java 17+**. Install **kotlin-lsp**:
+```bash
+# macOS with Homebrew
+brew install JetBrains/utils/kotlin-lsp
+```
+
+For manual installation, download from [releases](https://github.com/Kotlin/kotlin-lsp/releases) and add to PATH.
+
+> **Note:** Currently supports JVM-only Kotlin Gradle projects.
 
 </details>
 

--- a/kotlin-lsp/.lsp.json
+++ b/kotlin-lsp/.lsp.json
@@ -1,0 +1,14 @@
+{
+    "kotlin": {
+        "command": "kotlin-lsp",
+        "args": [],
+        "extensionToLanguage": {
+            ".kt": "kotlin",
+            ".kts": "kotlin"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    }
+}

--- a/kotlin-lsp/plugin.json
+++ b/kotlin-lsp/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "kotlin-lsp",
+  "version": "0.1.0",
+  "description": "Kotlin language server by JetBrains",
+  "author": {
+    "name": "Piebald LLC",
+    "email": "support@piebald.ai"
+  },
+  "repository": "https://github.com/Kotlin/kotlin-lsp",
+  "license": "Apache-2.0",
+  "keywords": [
+    "kotlin",
+    "lsp",
+    "language-server",
+    "jetbrains"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add kotlin-lsp plugin with `.lsp.json` and `plugin.json`
- Update marketplace.json with kotlin-lsp entry
- Add Kotlin setup instructions to README

## Details
Uses [kotlin-lsp](https://github.com/Kotlin/kotlin-lsp) from JetBrains. Requires Java 17+ and supports `.kt` and `.kts` files.

## Test plan
- [ ] Verify plugin installs via marketplace
- [ ] Test with a Kotlin Gradle project

🤖 Generated with [Claude Code](https://claude.com/claude-code)