### PR TITLE
Add lspServers config to vtsls plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,6 +21,20 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "vtsls": {
+          "command": "vtsls",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mjs": "javascript",
+            ".cjs": "javascript"
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to vtsls plugin entry in marketplace.json

Fixes #7

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the vtsls plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .ts/.tsx/.js/.jsx files