### PR TITLE
Add lspServers config to jdtls plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -87,6 +87,14 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "jdtls": {
+          "command": "jdtls",
+          "extensionToLanguage": {
+            ".java": "java"
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to jdtls plugin entry in marketplace.json

Fixes #11

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the jdtls plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .java files