### PR TITLE
Add lspServers config to ruby-lsp plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -123,6 +123,17 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "ruby-lsp": {
+          "command": "ruby-lsp",
+          "extensionToLanguage": {
+            ".rb": "ruby",
+            ".rbw": "ruby",
+            ".rake": "ruby",
+            ".gemspec": "ruby"
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to ruby-lsp plugin entry in marketplace.json

Fixes #13

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the ruby-lsp plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .rb/.rake/.gemspec files