### PR TITLE
Add lspServers config to vscode-langservers plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -141,6 +141,26 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "vscode-html-language-server": {
+          "command": "vscode-html-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".html": "html",
+            ".htm": "html"
+          }
+        },
+        "vscode-css-language-server": {
+          "command": "vscode-css-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".css": "css",
+            ".scss": "scss",
+            ".sass": "sass",
+            ".less": "less"
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to vscode-langservers plugin entry in marketplace.json
- Configures both HTML and CSS language servers

Fixes #14

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the vscode-langservers plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .html/.htm files
- [ ] Verify LSP works on .css/.scss/.sass/.less files