### PR TITLE
Add lspServers config to phpactor plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -157,6 +157,20 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "phpactor": {
+          "command": "phpactor",
+          "args": ["language-server"],
+          "extensionToLanguage": {
+            ".php": "php",
+            ".phtml": "php",
+            ".php3": "php",
+            ".php4": "php",
+            ".php5": "php",
+            ".phps": "php"
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to phpactor plugin entry in marketplace.json

Fixes #15

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the phpactor plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .php files