### PR TITLE
Add lspServers config to omnisharp plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -175,6 +175,16 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "omnisharp": {
+          "command": "OmniSharp",
+          "args": ["--languageserver"],
+          "extensionToLanguage": {
+            ".cs": "csharp",
+            ".csx": "csharp"
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to omnisharp plugin entry in marketplace.json

Fixes #16

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the omnisharp plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .cs/.csx files