### PR TITLE
Add lspServers config to powershell-editor-services plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -194,6 +194,17 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "powershell-editor-services": {
+          "command": "pwsh",
+          "args": ["-NoLogo", "-NoProfile", "-Command", "if (-not (Get-Module -ListAvailable PowerShellEditorServices)) { Install-Module -Name PowerShellEditorServices -Scope CurrentUser -Force }; Import-Module PowerShellEditorServices; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path (Get-Module PowerShellEditorServices -ListAvailable).Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"],
+          "extensionToLanguage": {
+            ".ps1": "powershell",
+            ".psm1": "powershell",
+            ".psd1": "powershell"
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to powershell-editor-services plugin entry in marketplace.json

Fixes #17

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the powershell-editor-services plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .ps1/.psm1/.psd1 files