### PR TITLE
Add lspServers config to kotlin-lsp plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -211,6 +211,15 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "kotlin-lsp": {
+          "command": "kotlin-lsp",
+          "extensionToLanguage": {
+            ".kt": "kotlin",
+            ".kts": "kotlin"
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to kotlin-lsp plugin entry in marketplace.json

Fixes #18

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the kotlin-lsp plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .kt/.kts files