### PR TITLE
Add lspServers config to texlab plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -229,6 +229,17 @@
       "author": {
         "name": "Micah Stubbs",
         "email": "git@micah.fyi"
+      },
+      "lspServers": {
+        "texlab": {
+          "command": "texlab",
+          "extensionToLanguage": {
+            ".tex": "latex",
+            ".bib": "bibtex",
+            ".cls": "latex",
+            ".sty": "latex"
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Add `lspServers` configuration to texlab plugin entry in marketplace.json

Fixes #19

## Root Cause

Claude Code reads LSP configuration from the `lspServers` field in marketplace.json, not from `.lsp.json` files in plugin directories.

## Test Plan

- [ ] Install/update the texlab plugin
- [ ] Restart Claude Code session  
- [ ] Verify LSP works on .tex/.bib/.cls/.sty files