### PR TITLE
fix(kotlin-lsp): add --stdio flag for proper stdio transport

### DIFF
--- a/kotlin-lsp/.lsp.json
+++ b/kotlin-lsp/.lsp.json
@@ -1,7 +1,7 @@
 {
     "kotlin": {
         "command": "kotlin-lsp",
-        "args": [],
+        "args": ["--stdio"],
         "extensionToLanguage": {
             ".kt": "kotlin",
             ".kts": "kotlin"


### PR DESCRIPTION
## Summary
- Add `--stdio` flag to kotlin-lsp args to enable stdio transport mode

## Problem
Without the `--stdio` flag, `kotlin-lsp` defaults to socket mode on port 9999. This causes the LSP server to appear stuck in "starting" state indefinitely when used with Claude Code, which expects stdio transport.

## Solution
Add `["--stdio"]` to the args array in `.lsp.json`, matching the pattern used by other LSP plugins and the documentation in `CLAUDE.md` which states: `args: Command-line arguments (typically ["--stdio"])`.

## Testing
Verified that after this change, all LSP operations work correctly:
- `documentSymbol` ✓
- `hover` ✓
- `goToDefinition` ✓
- `findReferences` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)