### PR TITLE
Add basedpyright LSP plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -56,6 +56,24 @@
       }
     },
     {
+      "name": "basedpyright",
+      "version": "0.1.0",
+      "source": "./basedpyright",
+      "description": "Python language server using basedpyright with stricter type checking",
+      "category": "development",
+      "tags": [
+        "python",
+        "lsp",
+        "language-server",
+        "type-checking",
+        "basedpyright"
+      ],
+      "author": {
+        "name": "Tyler Laprade",
+        "email": "tyler@tylerlaprade.com"
+      }
+    },
+    {
       "name": "gopls",
       "version": "0.1.0",
       "source": "./gopls",

--- a/basedpyright/.lsp.json
+++ b/basedpyright/.lsp.json
@@ -1,0 +1,17 @@
+{
+    "python": {
+        "command": "basedpyright-langserver",
+        "args": [
+            "--stdio"
+        ],
+        "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python",
+            ".pyw": "python"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    }
+}

--- a/basedpyright/plugin.json
+++ b/basedpyright/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "basedpyright",
+  "version": "0.1.0",
+  "description": "Python language server using basedpyright with stricter type checking",
+  "author": {
+    "name": "Tyler Laprade",
+    "email": "tyler@tylerlaprade.com"
+  },
+  "repository": "https://github.com/DetachHead/basedpyright",
+  "license": "MIT",
+  "keywords": ["python", "lsp", "language-server", "type-checking", "basedpyright"]
+}


### PR DESCRIPTION
## Summary

Adds [basedpyright](https://github.com/DetachHead/basedpyright) as an alternative Python LSP option.

basedpyright is a community fork of pyright with:
- Stricter type checking defaults
- Additional diagnostic rules
- Better error messages
- Active community development

This provides an option for users who prefer stricter Python type checking than the standard pyright configuration.

## Installation

Users will need to install basedpyright separately:

```bash
pip install basedpyright
# or
uv pip install basedpyright
```