### PR TITLE
Modernize LSP definitions and sync validation tooling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,8 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "claude-code-lsps",
+  "version": "1.0.0",
+  "description": "Claude Code marketplace providing language server integrations across popular programming languages.",
   "owner": {
     "name": "Piebald LLC",
     "email": "support@piebald.ai"
@@ -21,6 +24,26 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "typescript": {
+          "command": "vtsls",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".cjs": "javascript",
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mjs": "javascript",
+            ".ts": "typescript",
+            ".tsx": "typescriptreact"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -36,6 +59,19 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "rust": {
+          "command": "rust-analyzer",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".rs": "rust"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -53,6 +89,23 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "python": {
+          "command": "pyright-langserver",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python",
+            ".pyw": "python"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -71,6 +124,23 @@
       "author": {
         "name": "Tyler Laprade",
         "email": "tyler@tylerlaprade.com"
+      },
+      "lspServers": {
+        "python": {
+          "command": "basedpyright-langserver",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python",
+            ".pyw": "python"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -88,6 +158,19 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "go": {
+          "command": "gopls",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".go": "go"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -105,6 +188,21 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "java": {
+          "command": "jdtls",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".java": "java"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "startupTimeout": 90000,
+          "shutdownTimeout": 15000,
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -125,6 +223,28 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "cpp": {
+          "command": "clangd",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".c": "c",
+            ".c++": "cpp",
+            ".cc": "cpp",
+            ".cpp": "cpp",
+            ".cxx": "cpp",
+            ".h": "c",
+            ".h++": "cpp",
+            ".hh": "cpp",
+            ".hpp": "cpp",
+            ".hxx": "cpp"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -141,6 +261,31 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "ruby": {
+          "command": "ruby-lsp",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".gemspec": "ruby",
+            ".rake": "ruby",
+            ".rb": "ruby",
+            ".rbw": "ruby"
+          },
+          "filePatterns": [
+            "**/Gemfile",
+            "**/Rakefile",
+            "**/Brewfile",
+            "**/Podfile",
+            "**/Capfile",
+            "**/Guardfile",
+            "**/Vagrantfile"
+          ],
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -159,6 +304,38 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "css": {
+          "command": "vscode-css-language-server",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".css": "css",
+            ".less": "less",
+            ".sass": "sass",
+            ".scss": "scss"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        },
+        "html": {
+          "command": "vscode-html-language-server",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".htm": "html",
+            ".html": "html"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -175,6 +352,26 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "php": {
+          "command": "phpactor",
+          "args": [
+            "language-server"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".php": "php",
+            ".php3": "php",
+            ".php4": "php",
+            ".php5": "php",
+            ".phps": "php",
+            ".phtml": "php"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -193,6 +390,23 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "csharp": {
+          "command": "OmniSharp",
+          "args": [
+            "--languageserver"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".cs": "csharp",
+            ".csx": "csharp"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "startupTimeout": 90000,
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -212,6 +426,28 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "powershell": {
+          "command": "pwsh",
+          "args": [
+            "-NoLogo",
+            "-NoProfile",
+            "-Command",
+            "$module = Get-Module -ListAvailable PowerShellEditorServices | Sort-Object Version -Descending | Select-Object -First 1; if (-not $module) { throw 'PowerShellEditorServices is not installed. Run: Install-Module -Name PowerShellEditorServices -Scope CurrentUser' }; Import-Module $module.Path; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path $module.Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".ps1": "powershell",
+            ".psd1": "powershell",
+            ".psm1": "powershell"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "startupTimeout": 120000,
+          "shutdownTimeout": 20000,
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -229,6 +465,23 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "kotlin": {
+          "command": "kotlin-lsp",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".kt": "kotlin",
+            ".kts": "kotlin"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "startupTimeout": 60000,
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -247,6 +500,22 @@
       "author": {
         "name": "Micah Stubbs",
         "email": "git@micah.fyi"
+      },
+      "lspServers": {
+        "latex": {
+          "command": "texlab",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".bib": "bibtex",
+            ".cls": "latex",
+            ".sty": "latex",
+            ".tex": "latex"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -267,12 +536,17 @@
         "email": "nixel2007@gmail.com"
       },
       "lspServers": {
-        "bsl-language-server": {
+        "bsl": {
           "command": "bsl-language-server",
+          "args": [],
+          "transport": "stdio",
           "extensionToLanguage": {
             ".bsl": "bsl",
             ".os": "bsl"
-          }
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
         }
       }
     },
@@ -291,6 +565,26 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "julia": {
+          "command": "julia",
+          "args": [
+            "--startup-file=no",
+            "--history-file=no",
+            "--quiet",
+            "-e",
+            "using LanguageServer; runserver()"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".jl": "julia"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "startupTimeout": 90000,
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -309,6 +603,28 @@
       "author": {
         "name": "Piebald LLC",
         "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "vue": {
+          "command": "vue-language-server",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".vue": "vue"
+          },
+          "initializationOptions": {
+            "typescript": {
+              "tsdk": "node_modules/typescript/lib"
+            },
+            "vue": {
+              "hybridMode": false
+            }
+          },
+          "settings": {},
+          "maxRestarts": 3
+        }
       }
     },
     {
@@ -327,6 +643,27 @@
       "author": {
         "name": "yousleepwhen",
         "email": "yousleepwhen@gmail.com"
+      },
+      "lspServers": {
+        "ocaml": {
+          "command": "opam",
+          "args": [
+            "exec",
+            "--",
+            "ocamllsp"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".ml": "ocaml",
+            ".mli": "ocaml.interface",
+            ".mll": "ocamllex",
+            ".mly": "menhir"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "startupTimeout": 60000,
+          "maxRestarts": 3
+        }
       }
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,18 @@ This is a Claude Code marketplace containing LSP (Language Server Protocol) plug
 
 **Supported languages:** TypeScript/JavaScript, Rust, Python, Go, Java, Kotlin, C/C++, PHP, Ruby, C#, PowerShell, HTML/CSS, LaTeX, Julia, Vue, OCaml, BSL
 
+**Compatibility target:** Claude Code 2.1.50+ (latest release: 2.1.52)
+
 ## Repository Structure
 
 ```
-.claude-plugin/marketplace.json  # Marketplace manifest listing all plugins
+.claude-plugin/marketplace.json  # Marketplace manifest with generated lspServers for local plugins
 <language>/
   plugin.json                    # Plugin metadata (name, version, description, keywords)
-  .lsp.json                      # LSP configuration (command, args, file extensions, transport)
+  .lsp.json                      # Canonical LSP configuration (command, transport, mappings, timeouts)
+scripts/
+  sync-lsp-to-marketplace.mjs    # Generates marketplace lspServers from .lsp.json files
+  validate-lsp-definitions.mjs   # Validates consistency and schema constraints
 ```
 
 ## Adding a New LSP Plugin
@@ -46,6 +51,8 @@ This is a Claude Code marketplace containing LSP (Language Server Protocol) plug
     "transport": "stdio",
     "initializationOptions": {},
     "settings": {},
+    "startupTimeout": 60000,
+    "shutdownTimeout": 15000,
     "maxRestarts": 3
   }
 }
@@ -53,14 +60,23 @@ This is a Claude Code marketplace containing LSP (Language Server Protocol) plug
 
 4. Add entry to `.claude-plugin/marketplace.json` in the `plugins` array
 
-5. Add setup instructions to `README.md` in the language-specific details section
+5. Ensure the plugin has been added to `.claude-plugin/marketplace.json` `plugins[]` first
+
+6. Run `node scripts/sync-lsp-to-marketplace.mjs` to generate/update `lspServers` for the plugin
+
+7. Run `node scripts/validate-lsp-definitions.mjs`
+
+8. Add setup instructions to `README.md` in the language-specific details section
 
 ## LSP Configuration Fields
 
 - `command`: The executable to run (must be in PATH)
 - `args`: Command-line arguments (typically `["--stdio"]`)
 - `extensionToLanguage`: Maps file extensions to LSP language IDs
+- `filePatterns`: Optional glob patterns for extensionless language files (for example `Gemfile`)
 - `transport`: Always `"stdio"` for this project
+- `startupTimeout`: Optional server startup wait time in milliseconds (recommended for slow servers)
+- `shutdownTimeout`: Optional server shutdown wait time in milliseconds
 - `maxRestarts`: Number of restart attempts on crash (default: 3)
 - `initializationOptions` / `settings`: LSP-specific configuration objects
 
@@ -68,4 +84,4 @@ This is a Claude Code marketplace containing LSP (Language Server Protocol) plug
 
 - Each plugin directory name should match the LSP tool name (e.g., `rust-analyzer`, `gopls`, `pyright`)
 - The `.lsp.json` can define multiple language servers in one file (see `vscode-langservers` for HTML + CSS example)
-- Some LSPs require complex initialization (see `powershell-editor-services` for inline module loading example)
+- `.lsp.json` is canonical; generated `lspServers` in marketplace should not be hand-edited

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Download it and try it out for free!  **https://piebald.ai/**
 
 This repository contains a [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces) with plugins that offer LSP servers for TypeScript, Rust, Python, Go, Java, Kotlin, C/C++, PHP, Ruby, C#, PowerShell, HTML/CSS, LaTeX, Julia, Vue, OCaml, and BSL (1C:Enterprise).  [LSP servers](https://microsoft.github.io/language-server-protocol) provide powerful and familiar code intelligence features to IDEs, and now Claude Code directly.
 
-[**Claude Code officially supports LSP.**](https://www.reddit.com/r/ClaudeAI/comments/1otdfo9/lsp_is_coming_to_claude_code_and_you_can_try_it)  In 2.0.74 they officially added it to the [changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2074).  Previously, the new `LSP` builtin tool had to be enabled manaually via `$ENABLE_LSP_TOOL=1`.
+[**Claude Code officially supports LSP.**](https://www.reddit.com/r/ClaudeAI/comments/1otdfo9/lsp_is_coming_to_claude_code_and_you_can_try_it)  In 2.0.74 they officially added it to the [changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2074).  Previously, the new `LSP` builtin tool had to be enabled manually via `$ENABLE_LSP_TOOL=1`.
 
-Claude can the LSP tool to
+This marketplace currently targets **Claude Code 2.1.50+** (latest release: **2.1.52**) to use modern LSP configuration fields like `startupTimeout`.
+
+Claude can use the LSP tool to
 - Go to the definition for symbols (`goToDefinition`)
 - Go to the implementation for symbols (`goToImplementation`)
 - Hover over symbols (`hover`)
@@ -62,6 +64,21 @@ Then enable the plugins of your choice:
 5. Select the plugins you'd like with the spacebar (e.g. TypeScript, Rust)
 6. Press "i" to install them
 7. Restart Claude Code
+
+## LSP definition workflow (for contributors)
+
+- `.lsp.json` files are the canonical source of LSP configuration.
+- `.claude-plugin/marketplace.json` `lspServers` entries are generated from `.lsp.json`.
+- Do not hand-edit generated `lspServers` blocks.
+- `sync-lsp-to-marketplace` only updates plugins that already exist in marketplace `plugins[]`. Add a marketplace entry first when introducing a new plugin directory.
+- `validate-lsp-definitions` will fail if a plugin directory exists but is not referenced in marketplace `plugins[]`.
+
+Run this workflow after any LSP config change:
+
+```bash
+node scripts/sync-lsp-to-marketplace.mjs
+node scripts/validate-lsp-definitions.mjs
+```
 
 ## Language-specific setup instructions
 
@@ -244,7 +261,7 @@ brew install powershell/tap/powershell
 # See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu
 ```
 
-The **PowerShellEditorServices** module will be automatically installed on first use if not already present. To install it manually:
+The **PowerShellEditorServices** module is not installed automatically at runtime. Install it manually:
 ```powershell
 Install-Module -Name PowerShellEditorServices -Scope CurrentUser
 ```

--- a/jdtls/.lsp.json
+++ b/jdtls/.lsp.json
@@ -8,6 +8,8 @@
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},
+        "startupTimeout": 90000,
+        "shutdownTimeout": 15000,
         "maxRestarts": 3
     }
 }

--- a/julia-lsp/.lsp.json
+++ b/julia-lsp/.lsp.json
@@ -14,6 +14,7 @@
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},
+        "startupTimeout": 90000,
         "maxRestarts": 3
     }
 }

--- a/kotlin-lsp/.lsp.json
+++ b/kotlin-lsp/.lsp.json
@@ -9,6 +9,7 @@
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},
+        "startupTimeout": 60000,
         "maxRestarts": 3
     }
 }

--- a/ocaml-lsp/.lsp.json
+++ b/ocaml-lsp/.lsp.json
@@ -11,6 +11,7 @@
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},
+        "startupTimeout": 60000,
         "maxRestarts": 3
     }
 }

--- a/omnisharp/.lsp.json
+++ b/omnisharp/.lsp.json
@@ -11,6 +11,7 @@
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},
+        "startupTimeout": 90000,
         "maxRestarts": 3
     }
 }

--- a/powershell-editor-services/.lsp.json
+++ b/powershell-editor-services/.lsp.json
@@ -5,7 +5,7 @@
             "-NoLogo",
             "-NoProfile",
             "-Command",
-            "if (-not (Get-Module -ListAvailable PowerShellEditorServices)) { Install-Module -Name PowerShellEditorServices -Scope CurrentUser -Force }; Import-Module PowerShellEditorServices; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path (Get-Module PowerShellEditorServices -ListAvailable).Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
+            "$module = Get-Module -ListAvailable PowerShellEditorServices | Sort-Object Version -Descending | Select-Object -First 1; if (-not $module) { throw 'PowerShellEditorServices is not installed. Run: Install-Module -Name PowerShellEditorServices -Scope CurrentUser' }; Import-Module $module.Path; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path $module.Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
         ],
         "extensionToLanguage": {
             ".ps1": "powershell",
@@ -15,6 +15,8 @@
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},
+        "startupTimeout": 120000,
+        "shutdownTimeout": 20000,
         "maxRestarts": 3
     }
 }

--- a/ruby-lsp/.lsp.json
+++ b/ruby-lsp/.lsp.json
@@ -8,6 +8,15 @@
             ".rake": "ruby",
             ".gemspec": "ruby"
         },
+        "filePatterns": [
+            "**/Gemfile",
+            "**/Rakefile",
+            "**/Brewfile",
+            "**/Podfile",
+            "**/Capfile",
+            "**/Guardfile",
+            "**/Vagrantfile"
+        ],
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},

--- a/scripts/lsp-definition-utils.mjs
+++ b/scripts/lsp-definition-utils.mjs
@@ -1,0 +1,274 @@
+export const MARKETPLACE_SCHEMA_URL =
+  "https://anthropic.com/claude-code/marketplace.schema.json";
+
+export const ALLOWED_LSP_FIELDS = [
+  "command",
+  "args",
+  "transport",
+  "env",
+  "extensionToLanguage",
+  "filePatterns",
+  "workspaceFolder",
+  "initializationOptions",
+  "settings",
+  "startupTimeout",
+  "shutdownTimeout",
+  "restartOnCrash",
+  "maxRestarts",
+];
+
+export const LEGACY_LSP_FIELDS = ["languages", "fileExtensions"];
+
+export const MARKETPLACE_KEY_ORDER = [
+  "$schema",
+  "name",
+  "version",
+  "description",
+  "owner",
+  "plugins",
+];
+
+export const PLUGIN_KEY_ORDER = [
+  "name",
+  "version",
+  "source",
+  "description",
+  "category",
+  "tags",
+  "author",
+  "lspServers",
+];
+
+const ALLOWED_LSP_FIELD_SET = new Set(ALLOWED_LSP_FIELDS);
+const LEGACY_LSP_FIELD_SET = new Set(LEGACY_LSP_FIELDS);
+
+export function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function sortObjectDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortObjectDeep);
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const sorted = {};
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = sortObjectDeep(value[key]);
+  }
+  return sorted;
+}
+
+export function reorderKeys(value, preferredOrder) {
+  const result = {};
+  for (const key of preferredOrder) {
+    if (Object.hasOwn(value, key)) {
+      result[key] = value[key];
+    }
+  }
+
+  for (const key of Object.keys(value).sort()) {
+    if (!Object.hasOwn(result, key)) {
+      result[key] = value[key];
+    }
+  }
+
+  return result;
+}
+
+function normalizeExtensionToLanguage(value, context, errors) {
+  if (!isPlainObject(value)) {
+    errors.push(`${context} must be an object of extension -> languageId entries`);
+    return null;
+  }
+
+  const normalized = {};
+  for (const extension of Object.keys(value).sort()) {
+    const languageId = value[extension];
+    if (typeof languageId !== "string") {
+      errors.push(`${context}.${extension} must be a string`);
+      continue;
+    }
+    normalized[extension] = languageId;
+  }
+  return normalized;
+}
+
+function normalizeStringArray(value, context, errors) {
+  if (!Array.isArray(value)) {
+    errors.push(`${context} must be an array`);
+    return null;
+  }
+
+  const normalized = [];
+  for (const item of value) {
+    if (typeof item !== "string") {
+      errors.push(`${context} items must be strings`);
+      continue;
+    }
+    normalized.push(item);
+  }
+  return normalized;
+}
+
+function normalizeEnv(value, context, errors) {
+  if (!isPlainObject(value)) {
+    errors.push(`${context} must be an object of env var key/value pairs`);
+    return null;
+  }
+
+  const normalized = {};
+  for (const key of Object.keys(value).sort()) {
+    const envValue = value[key];
+    if (typeof envValue !== "string") {
+      errors.push(`${context}.${key} must be a string`);
+      continue;
+    }
+    normalized[key] = envValue;
+  }
+  return normalized;
+}
+
+function normalizeServerConfig(serverName, serverConfig, pluginLabel) {
+  const context = `${pluginLabel}.${serverName}`;
+  const errors = [];
+
+  if (!isPlainObject(serverConfig)) {
+    return {
+      normalized: null,
+      errors: [`${context} must be an object`],
+    };
+  }
+
+  for (const field of Object.keys(serverConfig)) {
+    if (LEGACY_LSP_FIELD_SET.has(field)) {
+      errors.push(`${context} uses legacy field "${field}"`);
+    }
+
+    if (!ALLOWED_LSP_FIELD_SET.has(field)) {
+      errors.push(`${context} uses unsupported field "${field}"`);
+    }
+  }
+
+  const normalized = {};
+  for (const key of ALLOWED_LSP_FIELDS) {
+    if (!Object.hasOwn(serverConfig, key)) {
+      continue;
+    }
+
+    const value = serverConfig[key];
+    if (key === "command" || key === "transport" || key === "workspaceFolder") {
+      if (typeof value !== "string") {
+        errors.push(`${context}.${key} must be a string`);
+        continue;
+      }
+      normalized[key] = value;
+      continue;
+    }
+
+    if (key === "args" || key === "filePatterns") {
+      const normalizedValue = normalizeStringArray(value, `${context}.${key}`, errors);
+      if (normalizedValue) {
+        normalized[key] = normalizedValue;
+      }
+      continue;
+    }
+
+    if (key === "extensionToLanguage") {
+      const normalizedValue = normalizeExtensionToLanguage(
+        value,
+        `${context}.${key}`,
+        errors,
+      );
+      if (normalizedValue) {
+        normalized[key] = normalizedValue;
+      }
+      continue;
+    }
+
+    if (key === "env") {
+      const normalizedValue = normalizeEnv(value, `${context}.${key}`, errors);
+      if (normalizedValue) {
+        normalized[key] = normalizedValue;
+      }
+      continue;
+    }
+
+    if (key === "initializationOptions" || key === "settings") {
+      if (!isPlainObject(value)) {
+        errors.push(`${context}.${key} must be an object`);
+        continue;
+      }
+      normalized[key] = sortObjectDeep(value);
+      continue;
+    }
+
+    if (
+      key === "startupTimeout" ||
+      key === "shutdownTimeout" ||
+      key === "maxRestarts"
+    ) {
+      if (!Number.isInteger(value) || value < 0) {
+        errors.push(`${context}.${key} must be a non-negative integer`);
+        continue;
+      }
+      normalized[key] = value;
+      continue;
+    }
+
+    if (key === "restartOnCrash") {
+      if (typeof value !== "boolean") {
+        errors.push(`${context}.${key} must be a boolean`);
+        continue;
+      }
+      normalized[key] = value;
+      continue;
+    }
+  }
+
+  if (!Object.hasOwn(normalized, "command")) {
+    errors.push(`${context}.command is required`);
+  }
+  if (!Object.hasOwn(normalized, "transport")) {
+    errors.push(`${context}.transport is required`);
+  }
+  if (!Object.hasOwn(normalized, "extensionToLanguage")) {
+    errors.push(`${context}.extensionToLanguage is required`);
+  }
+
+  return {
+    normalized: errors.length === 0 ? normalized : null,
+    errors,
+  };
+}
+
+export function normalizeLspServers(rawServers, pluginLabel) {
+  if (!isPlainObject(rawServers)) {
+    return {
+      normalized: null,
+      errors: [`${pluginLabel} must define an object of LSP servers`],
+    };
+  }
+
+  const normalized = {};
+  const errors = [];
+  for (const serverName of Object.keys(rawServers).sort()) {
+    const serverResult = normalizeServerConfig(
+      serverName,
+      rawServers[serverName],
+      pluginLabel,
+    );
+    if (serverResult.normalized) {
+      normalized[serverName] = serverResult.normalized;
+    }
+    errors.push(...serverResult.errors);
+  }
+
+  return {
+    normalized: errors.length === 0 ? normalized : null,
+    errors,
+  };
+}

--- a/scripts/sync-lsp-to-marketplace.mjs
+++ b/scripts/sync-lsp-to-marketplace.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import {
+  MARKETPLACE_SCHEMA_URL,
+  MARKETPLACE_KEY_ORDER,
+  PLUGIN_KEY_ORDER,
+  isPlainObject,
+  normalizeLspServers,
+  reorderKeys,
+} from "./lsp-definition-utils.mjs";
+
+const rootDir = process.cwd();
+const marketplacePath = path.join(rootDir, ".claude-plugin", "marketplace.json");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function readJson(jsonPath) {
+  const raw = await fs.readFile(jsonPath, "utf8");
+  return JSON.parse(raw);
+}
+
+async function sync() {
+  const marketplace = await readJson(marketplacePath);
+  assert(Array.isArray(marketplace.plugins), "marketplace.plugins must be an array");
+
+  // Keep the same schema identifier used by Anthropic's official marketplace manifest.
+  marketplace.$schema ??= MARKETPLACE_SCHEMA_URL;
+  marketplace.version ??= "1.0.0";
+  marketplace.description ??=
+    "Claude Code marketplace providing language server integrations across popular programming languages.";
+
+  let syncedCount = 0;
+  const orderedPlugins = [];
+  for (const plugin of marketplace.plugins) {
+    if (!isPlainObject(plugin)) {
+      orderedPlugins.push(plugin);
+      continue;
+    }
+
+    const updatedPlugin = { ...plugin };
+    if (typeof updatedPlugin.source === "string" && updatedPlugin.source.startsWith("./")) {
+      const pluginDirName = updatedPlugin.source.replace(/^\.\/+/, "");
+      const pluginDirPath = path.join(rootDir, pluginDirName);
+      const lspPath = path.join(pluginDirPath, ".lsp.json");
+
+      try {
+        await fs.access(lspPath);
+      } catch {
+        throw new Error(
+          `Expected .lsp.json for marketplace plugin "${updatedPlugin.name}" at ${updatedPlugin.source}`,
+        );
+      }
+
+      const lspConfig = await readJson(lspPath);
+      const lspResult = normalizeLspServers(
+        lspConfig,
+        updatedPlugin.name ?? pluginDirName,
+      );
+      assert(
+        lspResult.normalized !== null,
+        lspResult.errors.join("; "),
+      );
+
+      updatedPlugin.lspServers = lspResult.normalized;
+      syncedCount += 1;
+    }
+
+    orderedPlugins.push(reorderKeys(updatedPlugin, PLUGIN_KEY_ORDER));
+  }
+
+  marketplace.plugins = orderedPlugins;
+
+  const orderedMarketplace = reorderKeys(marketplace, MARKETPLACE_KEY_ORDER);
+  await fs.writeFile(
+    marketplacePath,
+    `${JSON.stringify(orderedMarketplace, null, 2)}\n`,
+    "utf8",
+  );
+
+  console.log(`Synced lspServers for ${syncedCount} plugins.`);
+}
+
+sync().catch((error) => {
+  console.error(`sync-lsp-to-marketplace failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/scripts/validate-lsp-definitions.mjs
+++ b/scripts/validate-lsp-definitions.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import {
+  isPlainObject,
+  normalizeLspServers,
+} from "./lsp-definition-utils.mjs";
+
+const rootDir = process.cwd();
+const marketplacePath = path.join(rootDir, ".claude-plugin", "marketplace.json");
+
+const slowStartupPluginDirs = new Set([
+  "jdtls",
+  "powershell-editor-services",
+  "omnisharp",
+  "julia-lsp",
+  "kotlin-lsp",
+  "ocaml-lsp",
+]);
+
+async function readJson(jsonPath) {
+  const raw = await fs.readFile(jsonPath, "utf8");
+  return JSON.parse(raw);
+}
+
+async function listPluginDirs() {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true });
+  const dirs = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith(".") || entry.name === "scripts") {
+      continue;
+    }
+
+    const dirPath = path.join(rootDir, entry.name);
+    const pluginJsonPath = path.join(dirPath, "plugin.json");
+    const lspJsonPath = path.join(dirPath, ".lsp.json");
+    const hasPluginJson = await fs
+      .access(pluginJsonPath)
+      .then(() => true)
+      .catch(() => false);
+    const hasLspJson = await fs
+      .access(lspJsonPath)
+      .then(() => true)
+      .catch(() => false);
+
+    if (hasPluginJson || hasLspJson) {
+      dirs.push({
+        name: entry.name,
+        pluginJsonPath,
+        lspJsonPath,
+        hasPluginJson,
+        hasLspJson,
+      });
+    }
+  }
+  return dirs;
+}
+
+async function validate() {
+  const errors = [];
+  const pluginDirs = await listPluginDirs();
+  const pluginDirNames = new Set(pluginDirs.map((item) => item.name));
+
+  for (const pluginDir of pluginDirs) {
+    if (!pluginDir.hasPluginJson) {
+      errors.push(`${pluginDir.name} is missing plugin.json`);
+    }
+    if (!pluginDir.hasLspJson) {
+      errors.push(`${pluginDir.name} is missing .lsp.json`);
+      continue;
+    }
+
+    const lspServers = await readJson(pluginDir.lspJsonPath);
+    const lspResult = normalizeLspServers(lspServers, `${pluginDir.name}/.lsp.json`);
+    errors.push(...lspResult.errors);
+
+    if (slowStartupPluginDirs.has(pluginDir.name)) {
+      for (const [serverName, serverConfig] of Object.entries(lspServers)) {
+        if (!Object.hasOwn(serverConfig, "startupTimeout")) {
+          errors.push(
+            `${pluginDir.name}/.lsp.json -> ${serverName} requires startupTimeout`,
+          );
+        }
+      }
+    }
+  }
+
+  const marketplace = await readJson(marketplacePath);
+  if (!Array.isArray(marketplace.plugins)) {
+    errors.push(".claude-plugin/marketplace.json must contain a plugins array");
+  } else {
+    const marketplaceSources = new Set();
+
+    for (const plugin of marketplace.plugins) {
+      if (!isPlainObject(plugin) || typeof plugin.source !== "string") {
+        continue;
+      }
+      if (!plugin.source.startsWith("./")) {
+        continue;
+      }
+
+      const pluginDir = plugin.source.replace(/^\.\/+/, "");
+      marketplaceSources.add(pluginDir);
+
+      if (!pluginDirNames.has(pluginDir)) {
+        errors.push(
+          `marketplace plugin "${plugin.name}" points to missing directory "${pluginDir}"`,
+        );
+        continue;
+      }
+
+      const expectedLspPath = path.join(rootDir, pluginDir, ".lsp.json");
+      const expectedLsp = await readJson(expectedLspPath);
+      const normalizedExpectedResult = normalizeLspServers(
+        expectedLsp,
+        `${pluginDir}/.lsp.json`,
+      );
+      const normalizedActualResult = normalizeLspServers(
+        plugin.lspServers,
+        `${plugin.name}.lspServers`,
+      );
+      errors.push(...normalizedExpectedResult.errors);
+      errors.push(...normalizedActualResult.errors);
+
+      if (
+        normalizedExpectedResult.normalized &&
+        normalizedActualResult.normalized &&
+        JSON.stringify(normalizedExpectedResult.normalized) !==
+          JSON.stringify(normalizedActualResult.normalized)
+      ) {
+        errors.push(
+          `marketplace plugin "${plugin.name}" has stale lspServers (run scripts/sync-lsp-to-marketplace.mjs)`,
+        );
+      }
+    }
+
+    for (const pluginDirName of pluginDirNames) {
+      if (!marketplaceSources.has(pluginDirName)) {
+        errors.push(
+          `plugin directory "${pluginDirName}" is not referenced in .claude-plugin/marketplace.json`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("LSP definition validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("LSP definition validation passed.");
+}
+
+validate().catch((error) => {
+  console.error(`validate-lsp-definitions failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/vscode-langservers/.lsp.json
+++ b/vscode-langservers/.lsp.json
@@ -4,13 +4,10 @@
         "args": [
             "--stdio"
         ],
-        "languages": [
-            "html"
-        ],
-        "fileExtensions": [
-            ".html",
-            ".htm"
-        ],
+        "extensionToLanguage": {
+            ".html": "html",
+            ".htm": "html"
+        },
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},
@@ -21,18 +18,12 @@
         "args": [
             "--stdio"
         ],
-        "languages": [
-            "css",
-            "scss",
-            "sass",
-            "less"
-        ],
-        "fileExtensions": [
-            ".css",
-            ".scss",
-            ".sass",
-            ".less"
-        ],
+        "extensionToLanguage": {
+            ".css": "css",
+            ".scss": "scss",
+            ".sass": "sass",
+            ".less": "less"
+        },
         "transport": "stdio",
         "initializationOptions": {},
         "settings": {},


### PR DESCRIPTION
## Summary

Big refactor to modernize the LSP marketplace definitions for Claude Code 2.1.50+ (latest: 2.1.52), makes `.lsp.json` canonical, and adds deterministic generation + validation tooling for marketplace `lspServers`.

## What changed

- Added LSP tooling scripts:
  - `scripts/sync-lsp-to-marketplace.mjs`
  - `scripts/validate-lsp-definitions.mjs`
  - `scripts/lsp-definition-utils.mjs` (shared normalization/validation logic)
- Generated `lspServers` in `.claude-plugin/marketplace.json` from per-plugin `.lsp.json`.
- Added marketplace metadata defaults:
  - `$schema`
  - `version`
  - `description`
- Updated slow-start server timeouts in `.lsp.json`:
  - `jdtls`, `powershell-editor-services`, `omnisharp`, `julia-lsp`, `kotlin-lsp`, `ocaml-lsp`
- Added Ruby `filePatterns` for extensionless files (`Gemfile`, `Rakefile`, etc.).
- Replaced legacy `languages` / `fileExtensions` in `vscode-langservers/.lsp.json` with `extensionToLanguage`.
- Removed runtime install side effects from PowerShell LSP startup command (module must be installed ahead of time).
- Updated docs (`README.md`, `CLAUDE.md`) for:
  - canonical `.lsp.json` workflow (`sync` -> `validate`)
  - 2.1.50+ compatibility note (with 2.1.52 as latest)
  - explicit note that sync does not auto-add new marketplace plugin entries

## Validation

- `node scripts/sync-lsp-to-marketplace.mjs`
- `node scripts/validate-lsp-definitions.mjs`

Both pass on this branch.

## Notes

- Shared normalization was extracted to avoid drift between sync and validate logic.
- `$schema` uses the same identifier Anthropic uses in their official marketplace manifest.
