### PR TITLE
Add Ada language server plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -656,6 +656,52 @@
           "maxRestarts": 3
         }
       }
+    },
+    {
+      "name": "ada-language-server",
+      "version": "0.1.0",
+      "source": "./ada-language-server",
+      "description": "Ada/SPARK and GPR language server",
+      "category": "development",
+      "tags": [
+        "ada",
+        "spark",
+        "gpr",
+        "lsp",
+        "language-server"
+      ],
+      "author": {
+        "name": "Quentin DAUPRAT",
+        "email": "cc-ada-lsp-support@adarium.dev"
+      },
+      "lspServers": {
+        "ada": {
+          "command": "ada_language_server",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".adb": "ada",
+            ".adc": "ada",
+            ".ads": "ada"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        },
+        "gpr": {
+          "command": "ada_language_server",
+          "args": [
+            "--language-gpr"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".gpr": "gpr"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
+      }
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Claude Code marketplace containing LSP (Language Server Protocol) plugins. Each plugin integrates a language server with Claude Code, providing code intelligence features like go-to-definition, find-references, hover info, and symbol search.
 
-**Supported languages:** TypeScript/JavaScript, Rust, Python, Go, Java, Kotlin, C/C++, PHP, Ruby, C#, PowerShell, HTML/CSS, LaTeX, Julia, Vue, OCaml, BSL
+**Supported languages:** TypeScript/JavaScript, Rust, Python, Go, Java, Kotlin, C/C++, PHP, Ruby, C#, PowerShell, HTML/CSS, LaTeX, Julia, Vue, OCaml, BSL, Ada
 
 **Compatibility target:** Claude Code 2.1.50+ (latest release: 2.1.52)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Download it and try it out for free!  **https://piebald.ai/**
 
 # Claude Code LSPs
 
-This repository contains a [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces) with plugins that offer LSP servers for TypeScript, Rust, Python, Go, Java, Kotlin, C/C++, PHP, Ruby, C#, PowerShell, HTML/CSS, LaTeX, Julia, Vue, OCaml, and BSL (1C:Enterprise).  [LSP servers](https://microsoft.github.io/language-server-protocol) provide powerful and familiar code intelligence features to IDEs, and now Claude Code directly.
+This repository contains a [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces) with plugins that offer LSP servers for TypeScript, Rust, Python, Go, Java, Kotlin, C/C++, PHP, Ruby, C#, PowerShell, HTML/CSS, LaTeX, Julia, Vue, OCaml, BSL (1C:Enterprise), and Ada.  [LSP servers](https://microsoft.github.io/language-server-protocol) provide powerful and familiar code intelligence features to IDEs, and now Claude Code directly.
 
 [**Claude Code officially supports LSP.**](https://www.reddit.com/r/ClaudeAI/comments/1otdfo9/lsp_is_coming_to_claude_code_and_you_can_try_it)  In 2.0.74 they officially added it to the [changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2074).  Previously, the new `LSP` builtin tool had to be enabled manually via `$ENABLE_LSP_TOOL=1`.
 
@@ -400,6 +400,37 @@ $env:PATH += ";$env:USERPROFILE\bsl-language-server\bin"
 ```
 
 The `bsl-language-server` executable needs to be in your PATH. Supports `.bsl` and `.os` files.
+
+</details>
+
+<details>
+<summary>Ada (<code>ada-language-server</code>)</summary>
+
+Install **ada_language_server** from AdaCore for Ada, SPARK, and GPR project support.
+
+**Using Alire (recommended):**
+```bash
+alr get ada_language_server
+cd ada_language_server*
+alr build
+# Add the bin directory to your PATH
+```
+
+**From GitHub releases:**
+
+Download pre-built binaries from [GitHub Releases](https://github.com/AdaCore/ada_language_server/releases).
+
+**From source:**
+```bash
+git clone https://github.com/AdaCore/ada_language_server.git
+cd ada_language_server
+make
+# Add the resulting executable to your PATH
+```
+
+The `ada_language_server` executable needs to be in your PATH. Supports `.adb` (body), `.ads` (spec), `.adc` (configuration), and `.gpr` (project) files.
+
+> **Note:** For best results, ensure your project has a valid `.gpr` project file. The language server uses GNAT project files to understand project structure and dependencies.
 
 </details>
 

--- a/ada-language-server/.lsp.json
+++ b/ada-language-server/.lsp.json
@@ -1,0 +1,26 @@
+{
+    "ada": {
+        "command": "ada_language_server",
+        "args": [],
+        "extensionToLanguage": {
+            ".adb": "ada",
+            ".ads": "ada",
+            ".adc": "ada"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    },
+    "gpr": {
+        "command": "ada_language_server",
+        "args": ["--language-gpr"],
+        "extensionToLanguage": {
+            ".gpr": "gpr"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    }
+}

--- a/ada-language-server/plugin.json
+++ b/ada-language-server/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ada-language-server",
+  "version": "0.1.0",
+  "description": "Ada/SPARK and GPR language server",
+  "author": {
+    "name": "Quentin DAUPRAT",
+    "email": "cc-ada-lsp-support@adarium.dev"
+  },
+  "repository": "https://github.com/AdaCore/ada_language_server",
+  "license": "GPL-3.0",
+  "keywords": [
+    "ada",
+    "spark",
+    "gpr",
+    "lsp",
+    "language-server"
+  ]
+}


### PR DESCRIPTION
Add support for Ada/SPARK and GPR languages using ada_language_server from AdaCore. Includes separate LSP configurations for Ada files (.adb, .ads, .adc) and GPR project files (.gpr) with --language-gpr flag.