### PR TITLE
feat(vscode-langservers): add ESLint language server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -322,6 +322,52 @@
           "settings": {},
           "maxRestarts": 3
         },
+        "eslint": {
+          "command": "vscode-eslint-language-server",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".astro": "astro",
+            ".cjs": "javascript",
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mjs": "javascript",
+            ".svelte": "svelte",
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".vue": "vue"
+          },
+          "initializationOptions": {},
+          "settings": {
+            "codeAction": {
+              "disableRuleComment": {
+                "enable": true,
+                "location": "separateLine"
+              },
+              "showDocumentation": {
+                "enable": true
+              }
+            },
+            "codeActionOnSave": {
+              "mode": "all"
+            },
+            "format": false,
+            "onIgnoredFiles": "off",
+            "problems": {
+              "shortenToSingleLine": false
+            },
+            "quiet": false,
+            "run": "onType",
+            "useESLintClass": true,
+            "validate": "on",
+            "workingDirectory": {
+              "mode": "location"
+            }
+          },
+          "maxRestarts": 3
+        },
         "html": {
           "command": "vscode-html-language-server",
           "args": [

--- a/README.md
+++ b/README.md
@@ -269,21 +269,26 @@ Install-Module -Name PowerShellEditorServices -Scope CurrentUser
 </details>
 
 <details>
-<summary>HTML/CSS (<code>vscode-langservers</code>)</summary>
+<summary>HTML/CSS/ESLint (<code>vscode-langservers</code>)</summary>
 
-Install **vscode-langservers-extracted** for both HTML and CSS:
+Install **@zed-industries/vscode-langservers-extracted** for HTML, CSS, and ESLint:
 ```bash
 # npm
-npm install -g vscode-langservers-extracted
+npm install -g @zed-industries/vscode-langservers-extracted
 
 # pnpm
-pnpm install -g vscode-langservers-extracted
+pnpm install -g @zed-industries/vscode-langservers-extracted
 
 # bun
-bun install -g vscode-langservers-extracted
+bun install -g @zed-industries/vscode-langservers-extracted
 ```
 
-This provides `vscode-html-language-server` and `vscode-css-language-server` executables.
+This provides `vscode-html-language-server`, `vscode-css-language-server`, and `vscode-eslint-language-server` executables.
+
+The ESLint language server requires ESLint to be installed in your project:
+```bash
+npm install --save-dev eslint
+```
 
 </details>
 

--- a/vscode-langservers/.lsp.json
+++ b/vscode-langservers/.lsp.json
@@ -28,5 +28,51 @@
         "initializationOptions": {},
         "settings": {},
         "maxRestarts": 3
+    },
+    "eslint": {
+        "command": "vscode-eslint-language-server",
+        "args": [
+            "--stdio"
+        ],
+        "extensionToLanguage": {
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mjs": "javascript",
+            ".cjs": "javascript",
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".vue": "vue",
+            ".svelte": "svelte",
+            ".astro": "astro"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {
+            "validate": "on",
+            "useESLintClass": true,
+            "run": "onType",
+            "format": false,
+            "quiet": false,
+            "onIgnoredFiles": "off",
+            "codeAction": {
+                "disableRuleComment": {
+                    "enable": true,
+                    "location": "separateLine"
+                },
+                "showDocumentation": {
+                    "enable": true
+                }
+            },
+            "codeActionOnSave": {
+                "mode": "all"
+            },
+            "problems": {
+                "shortenToSingleLine": false
+            },
+            "workingDirectory": {
+                "mode": "location"
+            }
+        },
+        "maxRestarts": 3
     }
 }

--- a/vscode-langservers/plugin.json
+++ b/vscode-langservers/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-langservers",
   "version": "0.1.0",
-  "description": "HTML and CSS language servers from VS Code",
+  "description": "HTML, CSS, and ESLint language servers from VS Code",
   "author": {
     "name": "Piebald LLC",
     "email": "support@piebald.ai"
   },
-  "repository": "https://github.com/hrsh7th/vscode-langservers-extracted",
+  "repository": "https://github.com/zed-industries/vscode-langservers-extracted",
   "license": "MIT",
-  "keywords": ["html", "css", "lsp", "language-server", "vscode"]
+  "keywords": ["html", "css", "eslint", "lsp", "language-server", "vscode"]
 }


### PR DESCRIPTION
## Summary

- Add ESLint language server to the existing `vscode-langservers` plugin using `vscode-eslint-language-server --stdio`
- Settings match [nvim-eslint](https://github.com/esmuellert/nvim-eslint) defaults (validate on, run onType, codeAction config, etc.)
- Covers `.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.vue`, `.svelte`, `.astro` files
- Update install instructions to use Zed's actively maintained fork (`@zed-industries/vscode-langservers-extracted`) which provides HTML, CSS, and ESLint language server binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)