### PR TITLE
Add Svelte LSP plugin (svelte-language-server)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -953,6 +953,39 @@
           "maxRestarts": 3
         }
       }
+    },
+    {
+      "name": "svelte-lsp",
+      "version": "0.1.0",
+      "source": "./svelte",
+      "description": "Svelte language server integration",
+      "category": "development",
+      "tags": [
+        "svelte",
+        "lsp",
+        "language-server"
+      ],
+      "author": {
+        "name": "RaviTharuma",
+        "email": "ravi.tharuma@lava.agency"
+      },
+      "lspServers": {
+        "svelte": {
+          "command": "svelteserver",
+          "args": [
+            "--stdio"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".svelte": "svelte"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "startupTimeout": 60000,
+          "shutdownTimeout": 15000,
+          "maxRestarts": 3
+        }
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Download it and try it out for free!  **https://piebald.ai/**
 
 # Claude Code LSPs
 
-This repository contains a [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces) with plugins that offer LSP servers for TypeScript, Rust, Python, Go, Java, Kotlin, Scala, C/C++, PHP, Ruby, C#, PowerShell, HTML/CSS, LaTeX, Julia, Vue, OCaml, BSL (1C:Enterprise), Ada, Dart, Solidity, and Markdown/mdbase.  [LSP servers](https://microsoft.github.io/language-server-protocol) provide powerful and familiar code intelligence features to IDEs, and now Claude Code directly.
+This repository contains a [Claude Code marketplace](https://code.claude.com/docs/en/plugin-marketplaces) with plugins that offer LSP servers for TypeScript, Rust, Python, Go, Java, Kotlin, Scala, C/C++, PHP, Ruby, C#, PowerShell, HTML/CSS, LaTeX, Julia, Vue, Svelte, OCaml, BSL (1C:Enterprise), Ada, Dart, Solidity, and Markdown/mdbase.  [LSP servers](https://microsoft.github.io/language-server-protocol) provide powerful and familiar code intelligence features to IDEs, and now Claude Code directly.
 
 [**Claude Code officially supports LSP.**](https://www.reddit.com/r/ClaudeAI/comments/1otdfo9/lsp_is_coming_to_claude_code_and_you_can_try_it)  In 2.0.74 they officially added it to the [changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2074).  Previously, the new `LSP` builtin tool had to be enabled manually via `$ENABLE_LSP_TOOL=1`.
 
@@ -398,6 +398,30 @@ The language server uses the project's `node_modules/typescript/lib` for type ch
 - Go-to-definition across `<template>`, `<script>`, `<style>`
 
 > **Note:** This plugin complements the existing `vtsls` plugin for TypeScript, providing full Vue + TS coverage.
+
+</details>
+
+<details>
+<summary>Svelte (<code>svelte-lsp</code>)</summary>
+
+Install **svelte-language-server** globally for Svelte Single File Component support:
+
+```bash
+# npm
+npm install -g svelte-language-server
+
+# bun
+bun add -g svelte-language-server
+
+# pnpm
+pnpm add -g svelte-language-server
+```
+
+This provides:
+- Diagnostics for `.svelte` files
+- Hover info and completions
+- Go-to-definition for components and props
+- TypeScript support within `<script>` blocks
 
 </details>
 

--- a/svelte/.lsp.json
+++ b/svelte/.lsp.json
@@ -1,0 +1,15 @@
+{
+    "svelte": {
+        "command": "svelteserver",
+        "args": ["--stdio"],
+        "extensionToLanguage": {
+            ".svelte": "svelte"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "startupTimeout": 60000,
+        "shutdownTimeout": 15000,
+        "maxRestarts": 3
+    }
+}

--- a/svelte/plugin.json
+++ b/svelte/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "svelte-lsp",
+  "version": "0.1.0",
+  "description": "Svelte language server integration",
+  "author": {
+    "name": "RaviTharuma",
+    "email": "ravi.tharuma@lava.agency"
+  },
+  "repository": "https://github.com/sveltejs/language-tools",
+  "license": "MIT",
+  "keywords": ["svelte", "lsp", "language-server"]
+}


### PR DESCRIPTION
## Summary

- Adds `svelte-lsp` plugin using `svelte-language-server` (`svelteserver` binary)
- Maps `.svelte` → `svelte` language ID
- Includes `startupTimeout: 60000` and `shutdownTimeout: 15000`
- Adds Svelte to the README supported languages list with install instructions
- Adds Svelte to the README plugin details section

## Installation

```bash
# npm
npm install -g svelte-language-server

# bun
bun add -g svelte-language-server

# pnpm
pnpm add -g svelte-language-server
```

## Validation

`SKIP_CLAUDE_RUNTIME_VALIDATE=1 node scripts/validate-all.mjs` passes (sync + LSP definition validation). 

Note: The runtime schema validation step (`claude plugin validate`) fails on the existing `$schema`, `version`, `description` keys in `.claude-plugin/marketplace.json` — this is a pre-existing issue unrelated to this PR and reproducible on the upstream `main` branch without any changes.

## Test plan

- [x] `svelte/plugin.json` and `svelte/.lsp.json` created following existing conventions
- [x] Entry added to `.claude-plugin/marketplace.json` plugins array
- [x] `SKIP_CLAUDE_RUNTIME_VALIDATE=1 node scripts/validate-all.mjs` passes
- [x] README updated with Svelte in supported languages list and install instructions