### PR TITLE
feat: add php-lsp — Rust-based PHP language server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -412,6 +412,55 @@
       }
     },
     {
+      "name": "php-lsp",
+      "version": "0.1.0",
+      "source": "./php-lsp",
+      "description": "Full-featured PHP language server written in Rust — semantic diagnostics, code actions, refactoring, PSR-4/Composer, PHPUnit test runner",
+      "category": "development",
+      "tags": [
+        "php",
+        "lsp",
+        "language-server",
+        "diagnostics",
+        "refactoring"
+      ],
+      "author": {
+        "name": "Jorg Sowa",
+        "email": "jorg.sowa@gmail.com"
+      },
+      "lspServers": {
+        "php": {
+          "command": "php-lsp",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".php": "php",
+            ".php3": "php",
+            ".php4": "php",
+            ".php5": "php",
+            ".phps": "php",
+            ".phtml": "php"
+          },
+          "initializationOptions": {
+            "diagnostics": {
+              "arityErrors": true,
+              "deprecatedCalls": true,
+              "duplicateDeclarations": true,
+              "enabled": true,
+              "typeErrors": true,
+              "undefinedClasses": true,
+              "undefinedFunctions": true,
+              "undefinedVariables": true
+            },
+            "excludePaths": [],
+            "phpVersion": "8.1"
+          },
+          "settings": {},
+          "maxRestarts": 3
+        }
+      }
+    },
+    {
       "name": "omnisharp",
       "version": "0.1.0",
       "source": "./omnisharp",

--- a/README.md
+++ b/README.md
@@ -250,6 +250,18 @@ Ensure `~/.composer/vendor/bin` (or `~/.config/composer/vendor/bin` on some syst
 </details>
 
 <details>
+<summary>PHP — php-lsp (<code>php-lsp</code>)</summary>
+
+Install **php-lsp** (requires [Rust](https://rustup.rs)):
+```bash
+cargo install php-lsp
+```
+
+The `php-lsp` executable needs to be in your PATH.
+
+</details>
+
+<details>
 <summary>Ruby (<code>ruby-lsp</code>)</summary>
 
 Install **ruby-lsp**:

--- a/php-lsp/.lsp.json
+++ b/php-lsp/.lsp.json
@@ -1,0 +1,31 @@
+{
+  "php": {
+    "command": "php-lsp",
+    "args": [],
+    "transport": "stdio",
+    "extensionToLanguage": {
+      ".php": "php",
+      ".php3": "php",
+      ".php4": "php",
+      ".php5": "php",
+      ".phps": "php",
+      ".phtml": "php"
+    },
+    "initializationOptions": {
+      "phpVersion": "8.1",
+      "excludePaths": [],
+      "diagnostics": {
+        "enabled": true,
+        "undefinedVariables": true,
+        "undefinedFunctions": true,
+        "undefinedClasses": true,
+        "arityErrors": true,
+        "typeErrors": true,
+        "deprecatedCalls": true,
+        "duplicateDeclarations": true
+      }
+    },
+    "settings": {},
+    "maxRestarts": 3
+  }
+}

--- a/php-lsp/plugin.json
+++ b/php-lsp/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "php-lsp",
+  "version": "0.1.0",
+  "description": "Full-featured PHP language server written in Rust — semantic diagnostics, code actions, refactoring, PSR-4/Composer, PHPUnit test runner",
+  "author": {
+    "name": "Jorg Sowa",
+    "email": "jorg.sowa@gmail.com"
+  },
+  "repository": "https://github.com/jorgsowa/php-lsp",
+  "license": "MIT",
+  "keywords": ["php", "lsp", "language-server", "diagnostics", "refactoring"]
+}


### PR DESCRIPTION
## Summary

- Adds [`php-lsp`](https://github.com/jorgsowa/php-lsp), a full-featured PHP language server written in Rust
- Coexists alongside the existing `phpactor` plugin as a separate entry
- Includes `php-lsp/plugin.json`, `php-lsp/.lsp.json`, and the generated marketplace entry

## Capabilities (beyond phpactor)

- **Semantic diagnostics** — undefined variables/functions/classes, arity errors, type errors, `@deprecated` warnings, duplicate declarations
- **Code actions** — add `use` import, generate constructor/getters/setters, implement missing methods, extract/inline variable, extract method, organize imports, add return type, add PHPDoc
- **Rename** — across all indexed files (functions, classes, variables, properties, `use` statements)
- **Navigation** — call hierarchy, type hierarchy, go-to-declaration, go-to-type-definition
- **Inlay hints** — parameter name labels, return-type labels
- **PHPUnit test runner** — "Run test" code lens on test methods
- **PSR-4/Composer** — autoload resolution via `composer.json`
- **PHPDoc type system** — `@template`, `@mixin`, Psalm/PHPStan tag aliases

## Install

```bash
cargo install php-lsp
```

## Test plan

- [ ] `node scripts/validate-all.mjs --skip-runtime` passes (runtime schema error is pre-existing, unrelated to this PR)
- [ ] `php-lsp/plugin.json` and `php-lsp/.lsp.json` present and valid
- [ ] Marketplace entry appears under `plugins[]` in `.claude-plugin/marketplace.json`