### PR TITLE
Add GraphQL language server plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1035,6 +1035,41 @@
           "maxRestarts": 3
         }
       }
+    },
+    {
+      "name": "graphql-lsp",
+      "version": "0.1.0",
+      "source": "./graphql-lsp",
+      "description": "GraphQL language server for schema and operation intelligence",
+      "category": "development",
+      "tags": [
+        "graphql",
+        "lsp",
+        "language-server",
+        "schema"
+      ],
+      "author": {
+        "name": "Dale Seo"
+      },
+      "lspServers": {
+        "graphql": {
+          "command": "graphql-lsp",
+          "args": [
+            "server",
+            "-m",
+            "stream"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".graphql": "graphql",
+            ".gql": "graphql",
+            ".graphqls": "graphql"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
+      }
     }
   ]
 }

--- a/graphql-lsp/.lsp.json
+++ b/graphql-lsp/.lsp.json
@@ -1,0 +1,15 @@
+{
+  "graphql": {
+    "command": "graphql-lsp",
+    "args": ["server", "-m", "stream"],
+    "transport": "stdio",
+    "extensionToLanguage": {
+      ".graphql": "graphql",
+      ".gql": "graphql",
+      ".graphqls": "graphql"
+    },
+    "initializationOptions": {},
+    "settings": {},
+    "maxRestarts": 3
+  }
+}

--- a/graphql-lsp/plugin.json
+++ b/graphql-lsp/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "graphql-lsp",
+  "version": "0.1.0",
+  "description": "GraphQL language server for schema and operation intelligence",
+  "author": {
+    "name": "Dale Seo"
+  },
+  "repository": "https://github.com/graphql/graphiql",
+  "license": "MIT",
+  "keywords": ["graphql", "lsp", "language-server", "schema"]
+}


### PR DESCRIPTION
Adds a GraphQL LSP plugin using graphql-lsp from graphql-language-service-cli, the official language server maintained by the GraphQL Foundation as part of the GraphiQL project. Supports .graphql, .gql, and .graphqls file extensions, providing diagnostics, completion, go-to-definition, and hover for GraphQL schemas and operations.