### PR TITLE
Add Haskell language server plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1037,6 +1037,40 @@
       }
     },
     {
+      "name": "haskell-language-server",
+      "version": "0.1.0",
+      "source": "./haskell-language-server",
+      "description": "Haskell language server with completion, references, type info, and document symbols",
+      "category": "development",
+      "tags": [
+        "haskell",
+        "lsp",
+        "language-server",
+        "hls",
+        "ghc"
+      ],
+      "author": {
+        "name": "Micah Stubbs",
+        "email": "git@micah.fyi"
+      },
+      "lspServers": {
+        "haskell": {
+          "command": "haskell-language-server-wrapper",
+          "args": [
+            "--lsp"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".hs": "haskell",
+            ".lhs": "haskell"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
+      }
+    },
+    {
       "name": "graphql-lsp",
       "version": "0.1.0",
       "source": "./graphql-lsp",
@@ -1061,8 +1095,8 @@
           ],
           "transport": "stdio",
           "extensionToLanguage": {
-            ".graphql": "graphql",
             ".gql": "graphql",
+            ".graphql": "graphql",
             ".graphqls": "graphql"
           },
           "initializationOptions": {},

--- a/haskell-language-server/.lsp.json
+++ b/haskell-language-server/.lsp.json
@@ -1,0 +1,14 @@
+{
+    "haskell": {
+        "command": "haskell-language-server-wrapper",
+        "args": ["--lsp"],
+        "extensionToLanguage": {
+            ".hs": "haskell",
+            ".lhs": "haskell"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    }
+}

--- a/haskell-language-server/plugin.json
+++ b/haskell-language-server/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "haskell-language-server",
+  "version": "0.1.0",
+  "description": "Haskell language server with completion, references, type info, and document symbols",
+  "author": {
+    "name": "Micah Stubbs",
+    "email": "git@micah.fyi"
+  },
+  "repository": "https://github.com/haskell/haskell-language-server",
+  "license": "Apache-2.0",
+  "keywords": ["haskell", "lsp", "language-server", "hls", "ghc"]
+}


### PR DESCRIPTION
Adds a Haskell LSP plugin using haskell-language-server-wrapper, the official language server for Haskell maintained by the Haskell community. Supports .hs and .lhs file extensions, providing diagnostics, completion, go-to-definition, hover, references, and document symbols. Uses the wrapper binary which automatically selects the correct HLS version for the project's GHC version.