### PR TITLE
Add ty plugin (Astral's Python type checker)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,42 @@
       }
     },
     {
+      "name": "ty",
+      "version": "0.1.0",
+      "source": "./ty",
+      "description": "Extremely fast Python type checker by Astral",
+      "category": "development",
+      "tags": [
+        "python",
+        "lsp",
+        "language-server",
+        "type-checking",
+        "ty",
+        "astral"
+      ],
+      "author": {
+        "name": "Piebald LLC",
+        "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "python": {
+          "command": "ty",
+          "args": [
+            "server"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python",
+            ".pyw": "python"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
+      }
+    },
+    {
       "name": "basedpyright",
       "version": "0.1.0",
       "source": "./basedpyright",

--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ bun install -g pyright
 </details>
 
 <details>
+<summary>Python (<code>ty</code>)</summary>
+
+Install **ty**, Astral's extremely fast Python type checker:
+```bash
+# uv (recommended)
+uv tool install ty
+
+# pip
+pip install ty
+```
+
+Make sure the `ty` executable is in your PATH. `ty` auto-detects `pyproject.toml` for project configuration.
+
+</details>
+
+<details>
 <summary>Go (<code>gopls</code>)</summary>
 
 Install **gopls**, the official Go language server:

--- a/ty/.lsp.json
+++ b/ty/.lsp.json
@@ -1,0 +1,17 @@
+{
+    "python": {
+        "command": "ty",
+        "args": [
+            "server"
+        ],
+        "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python",
+            ".pyw": "python"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    }
+}

--- a/ty/plugin.json
+++ b/ty/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "ty",
+  "version": "0.1.0",
+  "description": "Extremely fast Python type checker by Astral",
+  "author": {
+    "name": "Piebald LLC",
+    "email": "support@piebald.ai"
+  },
+  "repository": "https://github.com/astral-sh/ty",
+  "license": "MIT",
+  "keywords": ["python", "lsp", "language-server", "type-checking", "ty", "astral"]
+}


### PR DESCRIPTION
## Summary

Adds [`ty`](https://github.com/astral-sh/ty), Astral's extremely fast Python type checker, as a new LSP plugin in the marketplace.

`ty server` is a drop-in LSP — same protocol surface as pyright (hover, definition, references, document/workspace symbols, type hierarchy) but ~2× faster on large codebases.

## What's included

- `ty/.lsp.json` — canonical LSP config (`command: "ty server"`, stdio, `.py`/`.pyi`/`.pyw`)
- `ty/plugin.json` — plugin metadata
- `marketplace.json` — synced `lspServers` entry
- `README.md` — Python (`ty`) setup section under Language-specific setup instructions

## Validation

`node scripts/validate-all.mjs` passes:

```
==> Sync marketplace LSP servers
Synced lspServers for 30 plugins.
==> Validate repo LSP definitions
LSP definition validation passed.
==> Validate with Claude runtime schema
✔ Validation passed
All validations passed.
```

## Install

```bash
uv tool install ty   # or: pip install ty
```

`ty` auto-detects `pyproject.toml`; no extra LSP settings required.

## Test plan

- [x] `node scripts/validate-all.mjs` succeeds
- [x] Verified `ty server` responds to LSP `initialize` with full capabilities including `definitionProvider`, `referencesProvider`, `hoverProvider`, `documentSymbolProvider`, `workspaceSymbolProvider`
- [x] Tested as a standalone marketplace from a GitHub repo (`/plugin marketplace add` + `/plugin install`)