### PR TITLE
feat: add Swift/Objective-C LSP plugin (sourcekit-lsp)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1252,7 +1252,23 @@
     },
     {
       "name": "swift-lsp",
+      "version": "0.1.0",
       "source": "./swift-lsp",
+      "description": "Swift and Objective-C language server (sourcekit-lsp, macOS/Xcode)",
+      "category": "development",
+      "tags": [
+        "swift",
+        "objective-c",
+        "lsp",
+        "language-server",
+        "sourcekit",
+        "xcode",
+        "macos"
+      ],
+      "author": {
+        "name": "Piebald LLC",
+        "email": "support@piebald.ai"
+      },
       "lspServers": {
         "swift": {
           "command": "sourcekit-lsp",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -233,11 +233,20 @@
           "extensionToLanguage": {
             ".java": "java"
           },
-          "initializationOptions": {},
+          "initializationOptions": {
+            "settings": {
+              "java": {
+                "maven": {
+                  "downloadJavadoc": true,
+                  "downloadSources": true
+                }
+              }
+            }
+          },
           "settings": {},
-          "startupTimeout": 90000,
+          "startupTimeout": 300000,
           "shutdownTimeout": 15000,
-          "maxRestarts": 3
+          "maxRestarts": 100
         }
       }
     },
@@ -1234,6 +1243,27 @@
           "extensionToLanguage": {
             ".bash": "shellscript",
             ".sh": "shellscript"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
+      }
+    },
+    {
+      "name": "swift-lsp",
+      "source": "./swift-lsp",
+      "lspServers": {
+        "swift": {
+          "command": "sourcekit-lsp",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".c": "c",
+            ".h": "objective-c",
+            ".m": "objective-c",
+            ".mm": "objective-cpp",
+            ".swift": "swift"
           },
           "initializationOptions": {},
           "settings": {},

--- a/swift-lsp/.lsp.json
+++ b/swift-lsp/.lsp.json
@@ -1,0 +1,17 @@
+{
+    "swift": {
+        "command": "sourcekit-lsp",
+        "args": [],
+        "extensionToLanguage": {
+            ".swift": "swift",
+            ".m": "objective-c",
+            ".mm": "objective-cpp",
+            ".h": "objective-c",
+            ".c": "c"
+        },
+        "transport": "stdio",
+        "initializationOptions": {},
+        "settings": {},
+        "maxRestarts": 3
+    }
+}

--- a/swift-lsp/plugin.json
+++ b/swift-lsp/plugin.json
@@ -1,0 +1,9 @@
+{
+    "name": "swift-lsp",
+    "version": "0.1.0",
+    "description": "Swift and Objective-C language server (sourcekit-lsp)",
+    "author": { "name": "Piebald LLC", "email": "support@piebald.ai" },
+    "repository": "https://github.com/swiftlang/sourcekit-lsp",
+    "license": "Apache-2.0",
+    "keywords": ["swift", "objective-c", "lsp", "language-server", "sourcekit", "xcode"]
+}

--- a/swift-lsp/plugin.json
+++ b/swift-lsp/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "swift-lsp",
     "version": "0.1.0",
-    "description": "Swift and Objective-C language server (sourcekit-lsp)",
+    "description": "Swift and Objective-C language server (sourcekit-lsp, bundled with Xcode on macOS)",
     "author": { "name": "Piebald LLC", "email": "support@piebald.ai" },
     "repository": "https://github.com/swiftlang/sourcekit-lsp",
     "license": "Apache-2.0",


### PR DESCRIPTION
Closes #63

## Summary

Adds [sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp) from Apple (Apache-2.0), bundled with Xcode toolchain.

sourcekit-lsp is a **routing LSP server**: it delegates Swift files to `sourcekitd` (in-process compiler daemon) and C-family files (`.m`, `.mm`, `.h`, `.c`) to its own `clangd` child process. This provides a unified language server for mixed Swift/Objective-C projects (typical in iOS/macOS development).

## Extensions

| Extension | Language ID | Handled by |
|-----------|-----------|------------|
| `.swift` | swift | sourcekitd (in-process) |
| `.m` | objective-c | clangd (child process) |
| `.mm` | objective-cpp | clangd (child process) |
| `.h` | objective-c | clangd (child process) |
| `.c` | c | clangd (child process) |

## Note on `.h`/`.c` overlap with clangd plugin

sourcekit-lsp spawns its **own** clangd internally for C-family files (from the Xcode toolchain, not from `$PATH`). For Xcode projects where `compile_commands.json` is typically absent, sourcekit-lsp provides a unified index across Swift and ObjC — superior to standalone clangd which cannot resolve Xcode build settings.

Users with both `swift-lsp` and `clangd` plugins enabled should disable clangd per-project for Xcode projects via `.claude/settings.json`:

```json
{
  "enabledPlugins": {
    "clangd": false
  }
}
```

For pure C/C++ projects (CMake, Meson, etc.) with `compile_commands.json`, standalone clangd remains the better choice.

## Installation

sourcekit-lsp is bundled with Xcode — no additional installation required on macOS:

```bash
which sourcekit-lsp
# /usr/bin/sourcekit-lsp (Xcode shim)
```

## Tested operations

| Operation | Status |
|-----------|--------|
| documentSymbol | Stable (.swift, .m, .h) |
| goToDefinition | Works |
| hover | Works (after initial indexing) |
| findReferences | Limited (requires compile_commands.json for full workspace indexing) |