### PR TITLE
fix(jdtls): increase startupTimeout, add maxRestarts and Maven source downloads

### DIFF
--- a/jdtls/.lsp.json
+++ b/jdtls/.lsp.json
@@ -6,10 +6,19 @@
             ".java": "java"
         },
         "transport": "stdio",
-        "initializationOptions": {},
+        "initializationOptions": {
+            "settings": {
+                "java": {
+                    "maven": {
+                        "downloadSources": true,
+                        "downloadJavadoc": true
+                    }
+                }
+            }
+        },
         "settings": {},
-        "startupTimeout": 90000,
+        "startupTimeout": 300000,
         "shutdownTimeout": 15000,
-        "maxRestarts": 3
+        "maxRestarts": 100
     }
 }


### PR DESCRIPTION
## Summary

Three configuration improvements for the jdtls LSP entry, each fixing a real failure mode on large Java projects.

### 1. `startupTimeout` 90000 → 300000 ms

The current 90-second limit is insufficient for large Maven/Gradle projects. jdtls performs a full workspace index on first start — this routinely takes 60–90 seconds for codebases with hundreds of modules or transitive dependencies. The harness treats a timeout as a failed start and increments `maxRestarts`. Raising to 300s gives jdtls room to complete its initial import without false failures.

### 2. `maxRestarts` 3 → 100

With `maxRestarts: 3`, three unexpected restarts permanently disable the LSP for the session. This is too fragile: daemon-based setups (where the wrapper reconnects transparently) can consume restarts during initial setup, and a single genuine jdtls crash burns one restart forever. 100 is a practical ceiling that keeps the server alive through real-world turbulence without being infinite.

### 3. `initializationOptions.settings.java.maven.downloadSources/downloadJavadoc`

Without these, jdtls does not download `-sources.jar` files during Maven project import. Go-To-Definition on a library class returns `null` (or a `jdt://` URI that many clients cannot open) instead of the real source file. Setting `downloadSources: true` makes jdtls fetch source jars so navigation works for dependencies. `downloadJavadoc: true` enables hover documentation for the same classes.

## Test plan

- [ ] Open a large Maven project in Claude Code with the updated config
- [ ] Verify jdtls starts without timeout on first load
- [ ] Go-To-Definition on a Maven dependency class navigates to a source file
- [ ] Hover on a library class shows Javadoc
- [ ] Restarting Claude Code reconnects without exhausting `maxRestarts`