### PR TITLE
Add support for Gleam LSP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1174,6 +1174,38 @@
           "maxRestarts": 3
         }
       }
+    },
+    {
+      "name": "gleam",
+      "version": "0.1.0",
+      "source": "./gleam",
+      "description": "Gleam language server integration (bundled with the Gleam compiler)",
+      "category": "development",
+      "tags": [
+        "gleam",
+        "lsp",
+        "language-server",
+        "functional"
+      ],
+      "author": {
+        "name": "Piebald LLC",
+        "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "gleam": {
+          "command": "gleam",
+          "args": [
+            "lsp"
+          ],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".gleam": "gleam"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
+      }
     }
   ]
 }

--- a/gleam/.lsp.json
+++ b/gleam/.lsp.json
@@ -1,0 +1,13 @@
+{
+  "gleam": {
+    "command": "gleam",
+    "args": ["lsp"],
+    "transport": "stdio",
+    "extensionToLanguage": {
+      ".gleam": "gleam"
+    },
+    "initializationOptions": {},
+    "settings": {},
+    "maxRestarts": 3
+  }
+}

--- a/gleam/plugin.json
+++ b/gleam/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "gleam",
+  "version": "0.1.0",
+  "description": "Gleam language server integration (bundled with the Gleam compiler)",
+  "author": { "name": "Piebald LLC", "email": "support@piebald.ai" },
+  "repository": "https://github.com/gleam-lang/gleam",
+  "license": "Apache-2.0",
+  "keywords": ["gleam", "lsp", "language-server", "functional"]
+}


### PR DESCRIPTION
  - Adds a [Gleam](https://gleam.run) LSP plugin (gleam/).
  - The Gleam language server ships bundled with the Gleam compiler — no separate LSP binary to install. Install via the official [Gleam installation docs](https://gleam.run/install/).
  - The server is invoked as `gleam lsp` and communicates over stdio.
  - .claude-plugin/marketplace.json — new entry with generated lspServers block (synced by validate-all.mjs)

Verified working on my personal gleam projects.