### PR TITLE
Add perl-lsp (Perl language server)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1286,6 +1286,40 @@
           "maxRestarts": 3
         }
       }
+    },
+    {
+      "name": "perl-lsp",
+      "version": "0.1.0",
+      "source": "./perl-lsp",
+      "description": "Perl language server (perl-lsp) with type inference, cross-file navigation, and framework intelligence",
+      "category": "development",
+      "tags": [
+        "perl",
+        "lsp",
+        "language-server"
+      ],
+      "author": {
+        "name": "Piebald LLC",
+        "email": "support@piebald.ai"
+      },
+      "lspServers": {
+        "perl": {
+          "command": "perl-lsp",
+          "args": [],
+          "transport": "stdio",
+          "extensionToLanguage": {
+            ".cgi": "perl",
+            ".pl": "perl",
+            ".pm": "perl",
+            ".pod": "perl",
+            ".psgi": "perl",
+            ".t": "perl"
+          },
+          "initializationOptions": {},
+          "settings": {},
+          "maxRestarts": 3
+        }
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ gem install ruby-lsp
 <details>
 <summary>Perl (<code>perl-lsp</code>)</summary>
 
-Install **perl-lsp** (requires a Rust toolchain):
+Install **perl-lsp**. Download a prebuilt binary for your platform (macOS, Linux, Windows) from the [releases page](https://github.com/tree-sitter-perl/perl-tree-sitter-lsp/releases) and put `perl-lsp` on your `PATH`, or build from source with a Rust toolchain:
 ```bash
 cargo install perl-lsp
 ```

--- a/README.md
+++ b/README.md
@@ -288,6 +288,18 @@ gem install ruby-lsp
 </details>
 
 <details>
+<summary>Perl (<code>perl-lsp</code>)</summary>
+
+Install **perl-lsp** (requires a Rust toolchain):
+```bash
+cargo install perl-lsp
+```
+
+Provides type inference without annotations, cross-file navigation, and framework intelligence for Moo/Moose, Mojolicious, and DBIx::Class. See the [project page](https://github.com/tree-sitter-perl/perl-tree-sitter-lsp) for details.
+
+</details>
+
+<details>
 <summary>C# (<code>omnisharp</code>)</summary>
 
 Install **OmniSharp** (requires .NET SDK):

--- a/perl-lsp/.lsp.json
+++ b/perl-lsp/.lsp.json
@@ -1,0 +1,18 @@
+{
+  "perl": {
+    "command": "perl-lsp",
+    "args": [],
+    "transport": "stdio",
+    "extensionToLanguage": {
+      ".pl": "perl",
+      ".pm": "perl",
+      ".t": "perl",
+      ".pod": "perl",
+      ".psgi": "perl",
+      ".cgi": "perl"
+    },
+    "initializationOptions": {},
+    "settings": {},
+    "maxRestarts": 3
+  }
+}

--- a/perl-lsp/plugin.json
+++ b/perl-lsp/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "perl-lsp",
+  "version": "0.1.0",
+  "description": "Perl language server (perl-lsp) with type inference, cross-file navigation, and framework intelligence",
+  "author": { "name": "Piebald LLC", "email": "support@piebald.ai" },
+  "repository": "https://github.com/tree-sitter-perl/perl-tree-sitter-lsp",
+  "license": "Artistic-2.0",
+  "keywords": ["perl", "lsp", "language-server"]
+}


### PR DESCRIPTION
Adds **perl-lsp**, a Perl language server, following the contribution workflow in `CLAUDE.md` (new `perl-lsp/` directory with `plugin.json` + `.lsp.json`, marketplace entry, README setup block).

### About the server
[perl-lsp](https://github.com/tree-sitter-perl/perl-tree-sitter-lsp) is a Rust language server built on tree-sitter-perl. Highlights:
- **Type inference, no annotations** — types inferred from usage, flowing across files and through method chains.
- **Cross-file navigation** — goto-def / find-references / rename through inheritance and the workspace index.
- **Framework intelligence** — Moo/Moose `has`, Mojolicious (incl. route targets), and DBIx::Class (columns, relationships) contribute real symbols.

Installed via `cargo install perl-lsp` (on crates.io); also ships as a VS Code / OpenVSX extension.

### Config
Bare `perl-lsp` over stdio, no args; maps `.pl`/`.pm`/`.t`/`.pod`/`.psgi`/`.cgi` → `perl`. This is the first Perl entry in the marketplace.

### Validation
`node scripts/validate-all.mjs` passes — sync, LSP-definition validation, and Claude runtime schema validation all green. Diff is scoped to the new directory + entry + README; no other plugins touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)